### PR TITLE
feat(YTMusic): implement Next Song retrieval and parsing

### DIFF
--- a/src/@types/types.ts
+++ b/src/@types/types.ts
@@ -155,3 +155,15 @@ export const HomePageContent = type({
 		"[]",
 	],
 })
+
+export type NextResult = typeof NextResult.infer
+export const NextResult = type({
+      index: "number",
+	name: "string",
+      artist: "string",
+      playlistId: "string",
+      videoId: "string",
+      selected: "boolean",
+      params: "string",
+      thumbnails: [ThumbnailFull, "[]"],
+})

--- a/src/YTMusic.ts
+++ b/src/YTMusic.ts
@@ -7,6 +7,7 @@ import {
 	ArtistDetailed,
 	ArtistFull,
 	HomePageContent,
+	NextResult,
 	PlaylistDetailed,
 	PlaylistFull,
 	SearchResult,
@@ -18,6 +19,7 @@ import {
 import { FE_MUSIC_HOME } from "./constants"
 import AlbumParser from "./parsers/AlbumParser"
 import ArtistParser from "./parsers/ArtistParser"
+import NextParser from "./parsers/NextParser"
 import Parser from "./parsers/Parser"
 import PlaylistParser from "./parsers/PlaylistParser"
 import SearchParser from "./parsers/SearchParser"
@@ -527,4 +529,27 @@ export default class YTMusic {
 
 		return results
 	}
+
+      /**
+	 * Get content for next song.
+	 *
+       * @param videoId Video ID
+	 * @param playlistId Playlist ID
+       * @param paramString
+       * 
+	 * @returns List of the next song
+	 */
+      async getNext(videoId: string, playlistId: string, paramString?: string): Promise<NextResult[]> {
+            const data = await this.constructRequest('next', {
+                  enablePersistentPlaylistPanel: true,
+                  isAudioOnly: true,
+                  params: paramString,
+                  playlistId: playlistId,
+                  tunerSettingValue: "AUTOMIX_SETTING_NORMAL",
+                  videoId: videoId
+            });
+
+            const contents = traverse(traverseList(data, "tabs", "tabRenderer")[0], "contents");
+            return contents.map(NextParser.parse);
+      }
 }

--- a/src/parsers/NextParser.ts
+++ b/src/parsers/NextParser.ts
@@ -1,0 +1,23 @@
+import { NextResult } from "../@types/types"
+import checkType from "../utils/checkType"
+import { traverseList, traverseString } from "../utils/traverse"
+
+export default class NextParser {
+	public static parse(data: any): NextResult {
+            const playlistData = traverseString(data, "playlistPanelVideoRenderer");
+
+		return checkType(
+			{
+                        index: +traverseString(playlistData, "navigationEndpoint", "index"),
+				name: traverseString(playlistData, "title", "text"),
+				artist: traverseString(playlistData, "longBylineText", "text"),
+                        playlistId: traverseString(playlistData, "navigationEndpoint", "playlistId"),
+				videoId: traverseString(playlistData, "videoId"),
+                        selected: traverseString(playlistData, "selected") === "true",
+                        params: traverseString(playlistData, "navigationEndpoint", "params"),
+				thumbnails: traverseList(playlistData, "thumbnails")
+			},
+			NextResult,
+		)
+	}
+}


### PR DESCRIPTION
This method comes from youtube-music-api to get a list of songs in the UP NEXT tab.

- Added `getNext()` method in YTMusic class
- Added `NextResult` type in `types.ts`
- Created new parser `NextParser` class